### PR TITLE
fix: Ajoute un weight à la pipe en 3d

### DIFF
--- a/assets/minecraft/optifine/cit/general/outils/tabac/pipes/pipe.properties
+++ b/assets/minecraft/optifine/cit/general/outils/tabac/pipes/pipe.properties
@@ -1,4 +1,4 @@
 matchItems=minecraft:stick
 model=pipe.json
 nbt.display.Name=iregex:.*Pipe.*
-
+weight=5


### PR DESCRIPTION
Le renommage pipe d'un bâton garantis maintenant d'obtenir la pipe en 3d comme c'est le cas avec Optifine quel que soit l'interpréteur de CIT